### PR TITLE
Use Web IDL mixins

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,17 +128,16 @@ dictionary BrowserExtRuntimePort {
 };
 callback BrowserExtRuntimeSendNativeMessageCallback = void (any response);
 [NoInterfaceObject]
-partial interface BrowserExtBrowserRuntimeNativeMessaging {
+interface BrowserExtBrowserRuntimeNativeMessaging {
     BrowserExtRuntimePort connectNative(DOMString nativeServiceName);
     void sendNativeMessage(DOMString nativeServiceName, object message, optional RuntimeSendNativeMessageCallback callback);
     attribute BrowserExtRuntimePort Port;
 };
-[NoInterfaceObject, Exposed=Window,Ck_Any_Prm_nativeMessaging_]
-interface BrowserExtRuntimeNativeMessagingAPI {
+[Ck_Any_Prm_nativeMessaging_]
+interface mixin BrowserExtRuntimeNativeMessagingAPI {
     readonly attribute BrowserExtRuntimeNativeMessaging runtime; 
 };
-Browser implements BrowserExtRuntimeNativeMessagingAPI;
-
+Browser includes BrowserExtRuntimeNativeMessagingAPI;
 </pre>
             </section>
         </section>


### PR DESCRIPTION
https://github.com/heycam/webidl/pull/433 has introduced interface mixins and replaced `implements` with `includes`.

ReSpec will soon remove the support for `implements`, so this PR removes it before the removal happens.

See also https://github.com/heycam/webidl/issues/472